### PR TITLE
Eliminate redundant organization members retrieval

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,4 @@ const members = await githubApi.getOrganizationMembers({
 const members = await githubApi.getOrganizationMembers({
   owner: "organization-name",
   installationId: 123456
-});
-const members = await githubApi.getOrganizationMembers({
-  owner: "organization-name",
-  installationId: 123456
-});
+


### PR DESCRIPTION
Removed duplicate call to getOrganizationMembers.